### PR TITLE
Avoid AD type specific instances

### DIFF
--- a/src/tmb_objective_function.cpp
+++ b/src/tmb_objective_function.cpp
@@ -43,11 +43,18 @@ public:
     Variable a_min;
     Variable alpha;
     Variable beta;
-    
+    static vonBertalanffyInterface* instance;
+    vonBertalanffyInterface(){
+        instance = this;
+    }
     /**
      * Prepares the model to work with TMB.
      */
     void prepare(){
+        prepare_template<double>();
+    }
+    template<class Type>
+    void prepare_template(){
         
         // if(this->data.size() != this->ages.size()){
         //     std::cout<<"Error: ages vector length not equal to data vector length, abort\n";
@@ -58,118 +65,54 @@ public:
             Rcpp::stop("ages vector length not equal to data vector length");
         }
         
-        VonBertalanffyModel<double>* model_1 =
-        VonBertalanffyModel<double>::getInstance();
+        VonBertalanffyModel<Type>* model =
+        VonBertalanffyModel<Type>::getInstance();
         
-        VonBertalanffyModel<AD<double> >* model_2 =
-        VonBertalanffyModel<AD<double> >::getInstance();
+        model->clear();
         
-        VonBertalanffyModel<AD<AD<double> > >* model_3 =
-        VonBertalanffyModel<AD<AD<double> > >::getInstance();
+        model->predicted.resize(this->data.size());
         
-        VonBertalanffyModel<AD<AD<AD<double> > > >* model_4 =
-        VonBertalanffyModel<AD<AD<AD<double> > > >::getInstance();
-        
-        
-        model_1->clear();
-        model_2->clear();
-        model_3->clear();
-        model_4->clear();
-        
-        model_1->predicted.resize(model_1->data.size());
-        model_2->predicted.resize(model_1->data.size());
-        model_3->predicted.resize(model_1->data.size());
-        model_4->predicted.resize(model_1->data.size());
-        
-        model_1->ages.resize(this->ages.size());
-        model_1->data.resize(this->data.size());
-        model_2->ages.resize(this->ages.size());
-        model_2->data.resize(this->data.size());
-        model_3->ages.resize(this->ages.size());
-        model_3->data.resize(this->data.size());
-        model_4->ages.resize(this->ages.size());
-        model_4->data.resize(this->data.size());
+        model->ages.resize(this->ages.size());
+        model->data.resize(this->data.size());
         
         for(int i =0; i < this->data.size(); i++){
-            model_1->ages[i] = this->ages[i];
-            model_1->data[i] = this->data[i];
-            
-            model_2->ages[i] = this->ages[i];
-            model_2->data[i] = this->data[i];
-            
-            model_2->ages[i] = this->ages[i];
-            model_2->data[i] = this->data[i];
-            
-            model_3->ages[i] = this->ages[i];
-            model_3->data[i] = this->data[i];
-            
-            model_4->ages[i] = this->ages[i];
-            model_4->data[i] = this->data[i];
+            model->ages[i] = this->ages[i];
+            model->data[i] = this->data[i];
         }
         
         //initialize k
-        model_1->k = this->k.value;
-        model_2->k = this->k.value;
-        model_3->k = this->k.value;
-        model_4->k = this->k.value;
+        model->k = this->k.value;
         
         //initialize l_inf
-        model_1->l_inf = this->l_inf.value;
-        model_2->l_inf = this->l_inf.value;
-        model_3->l_inf = this->l_inf.value;
-        model_4->l_inf = this->l_inf.value;
+        model->l_inf = this->l_inf.value;
         
         //initialize a_min
-        model_1->a_min = this->a_min.value;
-        model_2->a_min = this->a_min.value;
-        model_3->a_min = this->a_min.value;
-        model_4->a_min = this->a_min.value;
+        model->a_min = this->a_min.value;
         
         //initialize alpha
-        model_1->alpha = this->alpha.value;
-        model_2->alpha = this->alpha.value;
-        model_3->alpha = this->alpha.value;
-        model_4->alpha = this->alpha.value;
+        model->alpha = this->alpha.value;
         
         //initialize beta
-        model_1->beta = this->beta.value;
-        model_2->beta = this->beta.value;
-        model_3->beta = this->beta.value;
-        model_4->beta = this->beta.value;
+        model->beta = this->beta.value;
         
         if(this->k.estimable){
-            model_1->parameters.push_back(&model_1->k);
-            model_2->parameters.push_back(&model_2->k);
-            model_3->parameters.push_back(&model_3->k);
-            model_4->parameters.push_back(&model_4->k);
+            model->parameters.push_back(&model->k);
         }
         
         if(this->l_inf.estimable){
-            model_1->parameters.push_back(&model_1->l_inf);
-            model_2->parameters.push_back(&model_2->l_inf);
-            model_3->parameters.push_back(&model_3->l_inf);
-            model_4->parameters.push_back(&model_4->l_inf);
+            model->parameters.push_back(&model->l_inf);
         }
         
         if(this->a_min.estimable){
-            model_1->parameters.push_back(&model_1->a_min);
-            model_2->parameters.push_back(&model_2->a_min);
-            model_3->parameters.push_back(&model_3->a_min);
-            model_4->parameters.push_back(&model_4->a_min);
+            model->parameters.push_back(&model->a_min);
         }
         
         if(this->alpha.estimable){
-            model_1->parameters.push_back(&model_1->alpha);
-            model_2->parameters.push_back(&model_2->alpha);
-            model_3->parameters.push_back(&model_3->alpha);
-            model_4->parameters.push_back(&model_4->alpha);
+            model->parameters.push_back(&model->alpha);
         }
         
         if(this->beta.estimable){
-            model_1->parameters.push_back(&model_1->beta);
-            model_2->parameters.push_back(&model_2->beta);
-            model_3->parameters.push_back(&model_3->beta);
-            model_4->parameters.push_back(&model_4->beta);
+            model->parameters.push_back(&model->beta);
         }
     }
     
@@ -221,6 +164,7 @@ public:
         
     }
 };
+vonBertalanffyInterface* vonBertalanffyInterface::instance = NULL;
 
 /**
  * Exposes the Variable and vonBertalanffyInterface classes to R.
@@ -289,6 +233,7 @@ template<typename Type>
 Type objective_function<Type>::operator()(){
     
     //get the singleton instance for type Type
+    vonBertalanffyInterface::instance->prepare_template<Type>();
     VonBertalanffyModel<Type>* model =
     VonBertalanffyModel<Type>::getInstance();
     


### PR DESCRIPTION
As I told @Andrea-Havron-NOAA it's best to avoid using nested AD types (as these are specific for CppAD).
This PR solves this problem. It also makes the interface less repetitive.
